### PR TITLE
json format fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 tmp
 test/expected/*.json
 *.swp
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,50 +1,48 @@
 {
-  "name": "grunt-sloc",
-  "description": "SLOC(source line of codes) plugin for Grunt.js",
-  "version": "0.5.2",
-  "homepage": "https://github.com/rhiokim/grunt-sloc",
-  "author": {
-    "name": "rhio kim",
-    "email": "rhio.kim@gmail.com",
-    "url": "http://about.me/rhio"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/rhiokim/grunt-sloc.git"
-  },
-  "bugs": {
-    "url": "https://github.com/rhiokim/grunt-sloc/issues"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/rhiokim/grunt-sloc/blob/master/LICENSE-MIT"
-    }
-  ],
-  "main": "Gruntfile.js",
-  "engines": {
-    "node": ">= 0.8.0"
-  },
-  "scripts": {
-    "test": "grunt test"
-  },
-  "dependencies": {
-    "readdir": "~0.0.13",
-    "sloc": "~0.1.1",
-    "ascii-table": "0.0.4"
-  },
-  "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.4.4"
-  },
-  "peerDependencies": {
-    "grunt": "~0.4.1"
-  },
-  "keywords": [
-    "gruntplugin",
-    "sloc"
-  ]
+	"name": "grunt-sloc",
+	"description": "SLOC(source line of codes) plugin for Grunt.js",
+	"version": "0.5.2",
+	"homepage": "https://github.com/rhiokim/grunt-sloc",
+	"author": {
+		"name": "rhio kim",
+		"email": "rhio.kim@gmail.com",
+		"url": "http://about.me/rhio"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/rhiokim/grunt-sloc.git"
+	},
+	"bugs": {
+		"url": "https://github.com/rhiokim/grunt-sloc/issues"
+	},
+	"licenses": [{
+		"type": "MIT",
+		"url": "https://github.com/rhiokim/grunt-sloc/blob/master/LICENSE-MIT"
+	}],
+	"main": "Gruntfile.js",
+	"engines": {
+		"node": ">= 0.8.0"
+	},
+	"scripts": {
+		"test": "grunt test"
+	},
+	"dependencies": {
+		"readdir": "~0.0.13",
+		"sloc": "~0.1.9",
+		"ascii-table": "0.0.4"
+	},
+	"devDependencies": {
+		"grunt-contrib-jshint": "~0.1.1",
+		"grunt-contrib-clean": "~0.4.0",
+		"grunt-contrib-nodeunit": "~0.1.2",
+		"grunt": "~0.4.1",
+		"grunt-contrib-watch": "~0.4.4"
+	},
+	"peerDependencies": {
+		"grunt": "~0.4.1"
+	},
+	"keywords": [
+		"gruntplugin",
+		"sloc"
+	]
 }


### PR DESCRIPTION
if the grunt configuration assume the form of
‘’sloc: {
			options: {
				reportType: 'json',
				reportPath: ‘<your path>’
			},
			‘yourFirstTarget’: {
				files: {
					‘path’: '**/*'
				}
			},
			'yourSecondTarget': {
				files: {
‘path1’: '**/*'
					‘path2’: '**/*'
				}
			}
		},

print a file with structure:
{
createdAt:’iso date of last creation’,
targets:[array of targets],
‘yourFirstTarget’:{
<sloc>,
createdAt:’iso date of last creation of the target’,
},
‘yourSecondTarget’:{
<sloc>,
createdAt:’iso date of last creation of the target’,
}
}