### PR TITLE
new feature: options.alias, custom ext to act like standard ext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 test/expected/*.json
 *.swp
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ Set as `false` to analyze only files with a subset of popular extensions.  `true
 
 If `true`, the SLOC will be executed on all of the files specified, regardless of file extension.  With 'tolerant' set to `false`, or 'tolerant' unspecified, only supported file extensions will be analyzed.
 
+#### options.alias
+Type: `Object`
+Default value: `null`
+
+Custom ext to act like standard ext.
+
+eg.
+
+```js
+{
+  php5: 'php',
+  less: 'css',
+  vm: 'html'
+}
+```
+
+
 ### Usage Examples
 
 #### Basic SLOC

--- a/tasks/sloc.js
+++ b/tasks/sloc.js
@@ -10,162 +10,179 @@
 
 module.exports = function (grunt) {
 
-	var fs = require('fs');
-	var sloc = require('sloc');
-	var readDir = require('readdir');
-	var AsciiTable = require('ascii-table');
-	var path = require('path');
+    var fs = require('fs');
+    var sloc = require('sloc');
+    var readDir = require('readdir');
+    var AsciiTable = require('ascii-table');
+    var path = require('path');
 
-	function resetCounter() {
-		return {
-			total: 0,
-			source: 0,
-			comment: 0,
-			single: 0,
-			block: 0,
-			mixed: 0,
-			empty: 0,
-			file: 0
-		};
-	}
+    function resetCounter() {
+        return {
+            total: 0,
+            source: 0,
+            comment: 0,
+            single: 0,
+            block: 0,
+            mixed: 0,
+            empty: 0,
+            file: 0
+        };
+    }
 
-	function resetD() {
-		return {
-			createdAt: new Date(),
-			total: resetCounter(),
-			targets: [],
-			data: {}
-		};
-	}
+    function resetD() {
+        return {
+            createdAt: new Date(),
+            total: resetCounter(),
+            targets: [],
+            data: {}
+        };
+    }
 
-	function getSlocFile(rPath) {
-		if (grunt.file.exists(rPath)) {
-			return grunt.file.readJSON(rPath);
-		} else {
-			return resetD();
-		}
-	}
+    function getSlocFile(rPath) {
+        if (grunt.file.exists(rPath)) {
+            return grunt.file.readJSON(rPath);
+        } else {
+            return resetD();
+        }
+    }
 
-	// Please see the Grunt documentation for more information regarding task
-	// creation: http://gruntjs.com/creating-tasks
+    // Please see the Grunt documentation for more information regarding task
+    // creation: http://gruntjs.com/creating-tasks
 
-	grunt.registerMultiTask('sloc', 'Source lines of code', function () {
-		// Merge task-specific and/or target-specific options with these defaults.
-		var options = this.options({
-			reportType: 'stdout', //stdout, json
-			reportPath: null,
-			reportDetail: true,
-			tolerant: false
-		});
-		var self = this;
-		var c, count = resetCounter();
+    grunt.registerMultiTask('sloc', 'Source lines of code', function () {
+        // Merge task-specific and/or target-specific options with these defaults.
+        var options = this.options({
+            reportType: 'stdout', //stdout, json
+            reportPath: null,
+            reportDetail: true,
+            tolerant: false,
+            alias: null
+        });
+        var self = this;
+        var c, count = resetCounter();
 
-		var exts = ['js', 'javascript', 'cc', 'c', 'html', 'css', 'scss', 'coffeescript', 'coffee', 'python', 'py', 'java', 'php', 'php5', 'go', 'less'];
+        var alias = options.alias || {};
+        var exts = ['js', 'javascript', 'cc', 'c', 'html', 'css', 'scss', 'coffeescript', 'coffee', 'python', 'py', 'java', 'php', 'php5', 'go', 'less'];
 
-		var d = (options.reportType === 'json') ? getSlocFile(options.reportPath) : resetD();
-		if (d.targets.indexOf(self.target) < 0) {
-			d.targets.push(self.target);
-		}
+        var d = (options.reportType === 'json') ? getSlocFile(options.reportPath) : resetD();
+        if (d.targets.indexOf(self.target) < 0) {
+            d.targets.push(self.target);
+        }
 
-		// Iterate over all specified file groups.
-		this.files.forEach(function (f) {
-			var src = readDir.readSync(f.dest, f.orig.src, readDir.ABSOLUTE_PATHS);
+        // Iterate over all specified file groups.
+        this.files.forEach(function (f) {
+            var src = readDir.readSync(f.dest, f.orig.src, readDir.ABSOLUTE_PATHS);
 
-			src.forEach(function (f) {
-				var stats, source = fs.readFileSync(f, 'utf8');
-				var ext = path.extname(f).replace(/^./, '');
-				var prop;
+            src.forEach(function (f) {
+                var stats, source = fs.readFileSync(f, 'utf8');
+                var ext = path.extname(f).replace(/^./, '');
+                var prop;
 
-				if (!ext) {
-					return;
-				}
+                if (!ext) {
+                    return;
+                }
 
-				if (!count.hasOwnProperty(ext)) {
-					count[ext] = resetCounter();
-				}
+                if (!count.hasOwnProperty(ext)) {
+                    count[ext] = resetCounter();
+                }
 
-				if (options.tolerant === true) {
-					if (exts.indexOf(ext) < 0) {
-						ext = 'js';
-					}
-				} else {
-					if (exts.indexOf(ext) < 0) {
-						return;
-					}
-				}
 
-				stats = sloc(source, ext);
-				c = count[ext];
-				c.file++;
+                var slocExt = ext;
+                if (options.tolerant === true && exts.indexOf(slocExt) < 0) {
+                    if (alias && alias[slocExt]) {
+                        slocExt = alias[slocExt];
+                    } else {
+                        slocExt = 'js';
+                    }
+                }
 
-				for (prop in stats) {
-					c[prop] += stats[prop];
-				}
+                if (exts.indexOf(slocExt) < 0) {
+                    return;
+                }
 
-				count.total += stats.total;
-				count.source += stats.source;
-				count.comment += stats.comment;
-				count.single += stats.single;
-				count.mixed += stats.mixed;
-				count.empty += stats.empty;
-				count.block += stats.block;
 
-				count.file++;
-			});
-		});
-		if (options.reportType === 'stdout') {
-			var table = new AsciiTable();
-			table.removeBorder();
+                stats = sloc(source, slocExt);
+                c = count[ext];
+                c.file++;
 
-			table.addRow('physical lines', String(count.total).green);
-			table.addRow('lines of source code', String(count.source).green);
-			table.addRow('total comment', String(count.comment).cyan);
-			table.addRow('singleline', String(count.single));
-			table.addRow('multiline', String(count.mixed));
-			table.addRow('empty', String(count.empty).red);
-			table.addRow('block', String(count.block));
-			table.addRow('', '');
-			table.addRow('number of files read', String(count.file).green);
-			table.addRow('mode', options.tolerant ? 'tolerant'.yellow : 'strict'.red);
-			table.addRow('', '');
+                for (prop in stats) {
+                    c[prop] += stats[prop];
+                }
 
-			grunt.log.writeln(' ');
-			grunt.log.writeln(table.toString());
+                count.total += stats.total;
+                count.source += stats.source;
+                count.comment += stats.comment;
+                count.single += stats.single;
+                count.mixed += stats.mixed;
+                count.empty += stats.empty;
+                count.block += stats.block;
 
-			if (options.reportDetail) {
-				table = new AsciiTable();
-				table.setHeading('extension', 'total', 'source', 'comment', 'single', 'mixed', 'empty', 'block');
+                count.file++;
+            });
+        });
 
-				exts.forEach(function (ext) {
-					c = count[ext];
-					if (c) {
-						table.addRow(ext, c.total, c.source, c.comment, c.single, c.mixed, c.empty, c.block);
-					}
-				});
-				grunt.log.writeln(table.toString());
-			}
+        // append alias ext
+        if (alias) {
+            Object.keys(alias).forEach(function (ext) {
+                if (exts.indexOf(ext) < 0) {
+                    exts.push(ext);
+                }
+            });
+        }
 
-			grunt.log.writeln(' ');
-		} else if (options.reportType === 'json') {
-			count.createdAt = new Date();
-			d.data[self.target] = count;
-			d.total = resetCounter();
-			d.targets.forEach(function (target) {
-				d.total.total += d.data[target].total;
-				d.total.source += d.data[target].source;
-				d.total.comment += d.data[target].comment;
-				d.total.single += d.data[target].single;
-				d.total.block += d.data[target].block;
-				d.total.mixed += d.data[target].mixed;
-				d.total.empty += d.data[target].empty;
-				d.total.file += d.data[target].file;
-			});
-			d.createdAt = count.createdAt;
-			if (!options.reportPath) {
-				grunt.log.warn('Please specify the reporting path.');
-			}
-			grunt.file.write(options.reportPath, JSON.stringify(d, null, 2));
-			grunt.log.writeln('Create at: ' + options.reportPath.cyan);
-		}
-	});
+        if (options.reportType === 'stdout') {
+            var table = new AsciiTable();
+            table.removeBorder();
+
+            table.addRow('physical lines', String(count.total).green);
+            table.addRow('lines of source code', String(count.source).green);
+            table.addRow('total comment', String(count.comment).cyan);
+            table.addRow('singleline', String(count.single));
+            table.addRow('multiline', String(count.mixed));
+            table.addRow('empty', String(count.empty).red);
+            table.addRow('block', String(count.block));
+            table.addRow('', '');
+            table.addRow('number of files read', String(count.file).green);
+            table.addRow('mode', options.tolerant ? 'tolerant'.yellow : 'strict'.red);
+            table.addRow('', '');
+
+            grunt.log.writeln(' ');
+            grunt.log.writeln(table.toString());
+
+            if (options.reportDetail) {
+                table = new AsciiTable();
+                table.setHeading('extension', 'total', 'source', 'comment', 'single', 'mixed', 'empty', 'block');
+
+                exts.forEach(function (ext) {
+                    c = count[ext];
+                    if (c) {
+                        table.addRow(ext, c.total, c.source, c.comment, c.single, c.mixed, c.empty, c.block);
+                    }
+                });
+                grunt.log.writeln(table.toString());
+            }
+
+            grunt.log.writeln(' ');
+        } else if (options.reportType === 'json') {
+            count.createdAt = new Date();
+            d.data[self.target] = count;
+            d.total = resetCounter();
+            d.targets.forEach(function (target) {
+                d.total.total += d.data[target].total;
+                d.total.source += d.data[target].source;
+                d.total.comment += d.data[target].comment;
+                d.total.single += d.data[target].single;
+                d.total.block += d.data[target].block;
+                d.total.mixed += d.data[target].mixed;
+                d.total.empty += d.data[target].empty;
+                d.total.file += d.data[target].file;
+            });
+            d.createdAt = count.createdAt;
+            if (!options.reportPath) {
+                grunt.log.warn('Please specify the reporting path.');
+            }
+            grunt.file.write(options.reportPath, JSON.stringify(d, null, 2));
+            grunt.log.writeln('Create at: ' + options.reportPath.cyan);
+        }
+    });
 };


### PR DESCRIPTION
options.alias

Custom ext to act like standard ext.

example:

```javascript
{
    vm: 'html'
}
```

Set velocity template file(*.vm) act as html.
